### PR TITLE
Add inert to visibility check

### DIFF
--- a/shared/domUtils.js
+++ b/shared/domUtils.js
@@ -81,11 +81,11 @@ function isVisible (element) {
     let computedStyle = window.getComputedStyle(el, null);
     let display = computedStyle.getPropertyValue('display');
     let visibility = computedStyle.getPropertyValue('visibility');
-    let hidden = el.getAttribute('hidden');
+    let inert = el.getAttribute('inert');
     let ariaHidden = el.getAttribute('aria-hidden');
 
     if ((display === 'none') || (visibility === 'hidden') ||
-        (hidden !== null) || (ariaHidden === 'true')) {
+        (inert !== null) || (ariaHidden === 'true')) {
       return false;
     }
     return isVisibleRec(el.parentNode);


### PR DESCRIPTION
This adds checking for the `inert` attribute to the isVisible() function that determines whether an element should be targeted for focus or not. It replaces the check for `hidden` because there's already a computed style check for `display: none`, checking for the `hidden` attribute is redundant.